### PR TITLE
feat!: Add admin UI and live cabinet light settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.mypy_cache
+__pycache__
+*.pyc
+
+api
+frontend
+
+.DS_Store
+.env
+.venv
+env
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,7 @@ cython_debug/
 
 #vscode
 .vscode/
+
+# Frontend dependencies and build output
+frontend/node_modules/
+frontend/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED=1
 
 # Install dependencies
 RUN apt-get update && \
-    apt-get -y install python3-smbus build-essential && \
+    apt-get -y install --no-install-recommends python3-smbus build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 # Set working directory
@@ -13,7 +13,7 @@ WORKDIR /usr/src/app
 
 # Copy requirements and install
 COPY requirements.txt ./
-RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application files
 COPY . .

--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -4,6 +4,9 @@
 __pycache__
 *.pyc
 
+api
+frontend
+
 .DS_Store
 .env
 .venv

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # dimepi
 Converting a Sound Leisure Dime Box controller to a Raspberry Pi powered Sonos controller
+
+## Track admin frontend
+
+The Docker Compose stack includes a small admin UI for editing the SQLite track database used by the main app.
+
+- `dimepi-api` exposes CRUD endpoints for the `tracks` table and mounts the shared `database` volume at `/var/lib/dimepi`.
+- `dimepi-frontend` serves the React app on port `8080` and proxies `/api` requests to `dimepi-api`.
+
+Run the stack and open `http://localhost:8080`:
+
+```sh
+docker compose up --build
+```
+
+The API is also exposed directly on `http://localhost:8000` for debugging.

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pyc
+.DS_Store

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-alpine
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/main.py
+++ b/api/main.py
@@ -263,9 +263,7 @@ def list_tracks():
             """
             SELECT key, track_name, artist_name, spotify_id
             FROM tracks
-            ORDER BY
-                CASE WHEN key GLOB '[0-9]*' THEN CAST(key AS INTEGER) ELSE NULL END,
-                key
+            ORDER BY key
             """
         ).fetchall()
         return [dict(row) for row in rows]

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,347 @@
+import os
+import re
+import sqlite3
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Response, status
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+
+DATABASE_PATH = os.environ.get("DIMEPI_DATABASE_PATH", "/var/lib/dimepi/database.db")
+DEFAULT_LIGHTS_COLOR = (255, 90, 0)
+DEFAULT_LIGHTS_ON_TIME = "07:00"
+DEFAULT_LIGHTS_OFF_TIME = "22:00"
+TIME_PATTERN = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+
+
+class TrackIn(BaseModel):
+    key: str = Field(min_length=1, max_length=16)
+    track_name: Optional[str] = ""
+    artist_name: Optional[str] = ""
+    spotify_id: str = Field(min_length=1)
+
+
+class TrackUpdate(BaseModel):
+    track_name: Optional[str] = ""
+    artist_name: Optional[str] = ""
+    spotify_id: str = Field(min_length=1)
+
+
+class Track(TrackIn):
+    pass
+
+
+class CabinetLightsPatch(BaseModel):
+    r: Optional[int] = Field(default=None, ge=0, le=255)
+    g: Optional[int] = Field(default=None, ge=0, le=255)
+    b: Optional[int] = Field(default=None, ge=0, le=255)
+    on_time: Optional[str] = None
+    off_time: Optional[str] = None
+
+
+class CabinetLightsSettings(BaseModel):
+    r: int
+    g: int
+    b: int
+    on_time: str
+    off_time: str
+    saved_r: int
+    saved_g: int
+    saved_b: int
+    saved_on_time: str
+    saved_off_time: str
+    has_unsaved_changes: bool
+
+
+app = FastAPI(title="DimePi Admin API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=os.environ.get("CORS_ALLOW_ORIGINS", "*").split(","),
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def get_connection():
+    os.makedirs(os.path.dirname(DATABASE_PATH), exist_ok=True)
+    connection = sqlite3.connect(DATABASE_PATH)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA busy_timeout = 5000")
+    return connection
+
+
+def init_database():
+    with get_connection() as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tracks (
+                key TEXT PRIMARY KEY,
+                track_name TEXT,
+                artist_name TEXT,
+                spotify_id TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS credits (
+                id INTEGER PRIMARY KEY,
+                credit_count INTEGER NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS cabinet_lights_settings (
+                id INTEGER PRIMARY KEY,
+                current_r INTEGER NOT NULL,
+                current_g INTEGER NOT NULL,
+                current_b INTEGER NOT NULL,
+                saved_r INTEGER NOT NULL,
+                saved_g INTEGER NOT NULL,
+                saved_b INTEGER NOT NULL,
+                current_on_time TEXT NOT NULL,
+                current_off_time TEXT NOT NULL,
+                saved_on_time TEXT NOT NULL,
+                saved_off_time TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO cabinet_lights_settings (
+                id,
+                current_r,
+                current_g,
+                current_b,
+                saved_r,
+                saved_g,
+                saved_b,
+                current_on_time,
+                current_off_time,
+                saved_on_time,
+                saved_off_time
+            )
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                DEFAULT_LIGHTS_COLOR[0],
+                DEFAULT_LIGHTS_COLOR[1],
+                DEFAULT_LIGHTS_COLOR[2],
+                DEFAULT_LIGHTS_COLOR[0],
+                DEFAULT_LIGHTS_COLOR[1],
+                DEFAULT_LIGHTS_COLOR[2],
+                DEFAULT_LIGHTS_ON_TIME,
+                DEFAULT_LIGHTS_OFF_TIME,
+                DEFAULT_LIGHTS_ON_TIME,
+                DEFAULT_LIGHTS_OFF_TIME,
+            ),
+        )
+
+
+def validate_time(value: Optional[str], field_name: str):
+    if value is not None and not TIME_PATTERN.match(value):
+        raise HTTPException(status_code=422, detail=f"{field_name} must use HH:MM in 24-hour time")
+
+
+def cabinet_lights_response(row):
+    return {
+        "r": row["current_r"],
+        "g": row["current_g"],
+        "b": row["current_b"],
+        "on_time": row["current_on_time"],
+        "off_time": row["current_off_time"],
+        "saved_r": row["saved_r"],
+        "saved_g": row["saved_g"],
+        "saved_b": row["saved_b"],
+        "saved_on_time": row["saved_on_time"],
+        "saved_off_time": row["saved_off_time"],
+        "has_unsaved_changes": (
+            row["current_r"],
+            row["current_g"],
+            row["current_b"],
+            row["current_on_time"],
+            row["current_off_time"],
+        ) != (
+            row["saved_r"],
+            row["saved_g"],
+            row["saved_b"],
+            row["saved_on_time"],
+            row["saved_off_time"],
+        ),
+    }
+
+
+@app.on_event("startup")
+def startup():
+    init_database()
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.get("/cabinet-lights", response_model=CabinetLightsSettings)
+def get_cabinet_lights():
+    with get_connection() as connection:
+        row = connection.execute(
+            """
+            SELECT current_r, current_g, current_b, saved_r, saved_g, saved_b,
+                   current_on_time, current_off_time, saved_on_time, saved_off_time
+            FROM cabinet_lights_settings
+            WHERE id = 1
+            """
+        ).fetchone()
+        if row is None:
+            init_database()
+            return get_cabinet_lights()
+        return cabinet_lights_response(row)
+
+
+@app.patch("/cabinet-lights/preview", response_model=CabinetLightsSettings)
+def preview_cabinet_lights(settings: CabinetLightsPatch):
+    validate_time(settings.on_time, "on_time")
+    validate_time(settings.off_time, "off_time")
+    with get_connection() as connection:
+        connection.execute(
+            """
+            UPDATE cabinet_lights_settings
+            SET current_r = COALESCE(?, current_r),
+                current_g = COALESCE(?, current_g),
+                current_b = COALESCE(?, current_b),
+                current_on_time = COALESCE(?, current_on_time),
+                current_off_time = COALESCE(?, current_off_time)
+            WHERE id = 1
+            """,
+            (settings.r, settings.g, settings.b, settings.on_time, settings.off_time),
+        )
+    return get_cabinet_lights()
+
+
+@app.post("/cabinet-lights/save", response_model=CabinetLightsSettings)
+def save_cabinet_lights():
+    with get_connection() as connection:
+        connection.execute(
+            """
+            UPDATE cabinet_lights_settings
+            SET saved_r = current_r,
+                saved_g = current_g,
+                saved_b = current_b,
+                saved_on_time = current_on_time,
+                saved_off_time = current_off_time
+            WHERE id = 1
+            """
+        )
+    return get_cabinet_lights()
+
+
+@app.post("/cabinet-lights/revert", response_model=CabinetLightsSettings)
+def revert_cabinet_lights():
+    with get_connection() as connection:
+        connection.execute(
+            """
+            UPDATE cabinet_lights_settings
+            SET current_r = saved_r,
+                current_g = saved_g,
+                current_b = saved_b,
+                current_on_time = saved_on_time,
+                current_off_time = saved_off_time
+            WHERE id = 1
+            """
+        )
+    return get_cabinet_lights()
+
+
+@app.get("/tracks", response_model=list[Track])
+def list_tracks():
+    with get_connection() as connection:
+        rows = connection.execute(
+            """
+            SELECT key, track_name, artist_name, spotify_id
+            FROM tracks
+            ORDER BY
+                CASE WHEN key GLOB '[0-9]*' THEN CAST(key AS INTEGER) ELSE NULL END,
+                key
+            """
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+
+@app.post("/tracks", response_model=Track, status_code=status.HTTP_201_CREATED)
+def create_track(track: TrackIn):
+    key = track.key.strip()
+    spotify_id = track.spotify_id.strip()
+    if not key or not spotify_id:
+        raise HTTPException(status_code=422, detail="Key and Spotify ID are required")
+
+    try:
+        with get_connection() as connection:
+            connection.execute(
+                """
+                INSERT INTO tracks (key, track_name, artist_name, spotify_id)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    key,
+                    track.track_name.strip() if track.track_name else "",
+                    track.artist_name.strip() if track.artist_name else "",
+                    spotify_id,
+                ),
+            )
+    except sqlite3.IntegrityError as exc:
+        raise HTTPException(status_code=409, detail="Track key already exists") from exc
+    return get_track(key)
+
+
+@app.get("/tracks/{key}", response_model=Track)
+def get_track(key: str):
+    with get_connection() as connection:
+        row = connection.execute(
+            """
+            SELECT key, track_name, artist_name, spotify_id
+            FROM tracks
+            WHERE key = ?
+            """,
+            (key,),
+        ).fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Track not found")
+        return dict(row)
+
+
+@app.put("/tracks/{key}", response_model=Track)
+def update_track(key: str, track: TrackUpdate):
+    spotify_id = track.spotify_id.strip()
+    if not spotify_id:
+        raise HTTPException(status_code=422, detail="Spotify ID is required")
+
+    with get_connection() as connection:
+        cursor = connection.execute(
+            """
+            UPDATE tracks
+            SET track_name = ?, artist_name = ?, spotify_id = ?
+            WHERE key = ?
+            """,
+            (
+                track.track_name.strip() if track.track_name else "",
+                track.artist_name.strip() if track.artist_name else "",
+                spotify_id,
+                key,
+            ),
+        )
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Track not found")
+    return get_track(key)
+
+
+@app.delete("/tracks/{key}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_track(key: str):
+    with get_connection() as connection:
+        cursor = connection.execute("DELETE FROM tracks WHERE key = ?", (key,))
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Track not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,2 @@
+fastapi-slim==0.111.0
+uvicorn==0.30.1

--- a/cabinet_lights.py
+++ b/cabinet_lights.py
@@ -19,9 +19,24 @@ def set_color(pixels, r, g, b):
     pixels[0] = (r, g, b)
     return pixels
 
-async def scheduler(pixels, r, g, b, on_time, off_time):
+def _parse_time(value):
+    return datetime.strptime(value, '%H:%M').time()
+
+async def scheduler(pixels, settings_provider):
     lights_on = True
+    applied_color = None
     while True:
+        settings = settings_provider()
+        if not settings:
+            await asyncio.sleep(1)
+            continue
+
+        r = settings["r"]
+        g = settings["g"]
+        b = settings["b"]
+        color = (r, g, b)
+        on_time = _parse_time(settings["on_time"])
+        off_time = _parse_time(settings["off_time"])
         now = datetime.now().time()
         if now >= off_time or now < on_time:
             if lights_on:
@@ -33,5 +48,10 @@ async def scheduler(pixels, r, g, b, on_time, off_time):
                 logging.info("Turning ON cabinet lights (day mode).")
                 turn_on(pixels, r, g, b)
                 lights_on = True
-        logging.debug(f"Lighting scheduler tick: now={now}, on_time={on_time}, off_time={off_time}")
-        await asyncio.sleep(60)
+            elif applied_color != color:
+                logging.info("Updating cabinet light colour.")
+                turn_on(pixels, r, g, b)
+
+        applied_color = color if lights_on else None
+        logging.debug(f"Lighting scheduler tick: now={now}, on_time={on_time}, off_time={off_time}, color={color}")
+        await asyncio.sleep(1)

--- a/database.py
+++ b/database.py
@@ -22,14 +22,29 @@ class Credits(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     credit_count: int
 
+class CabinetLightsSettings(SQLModel, table=True):
+    __tablename__ = "cabinet_lights_settings"
+
+    id: Optional[int] = Field(default=1, primary_key=True)
+    current_r: int
+    current_g: int
+    current_b: int
+    saved_r: int
+    saved_g: int
+    saved_b: int
+    current_on_time: str
+    current_off_time: str
+    saved_on_time: str
+    saved_off_time: str
+
 engine = create_engine(f"sqlite:///{database_path}")
 
-# Create tables only if database file doesn't exist yet
+# Create any missing tables. Existing tables are left unchanged.
 if not db_exists:
     logging.info(f"Database file {database_path} not found. Creating new database and tables.")
-    SQLModel.metadata.create_all(engine)
 else:
     logging.info(f"Database file {database_path} found. Using existing database.")
+SQLModel.metadata.create_all(engine)
 
 ###################################################################################
 #################### Functions for managing tracks ################################
@@ -136,3 +151,41 @@ def decrement_credits():
         else:
             logging.error(f'Credit count unset')
             return None
+
+###################################################################################
+#################### Functions for cabinet light settings ##########################
+###################################################################################
+
+def ensure_cabinet_lights_settings(r: int, g: int, b: int, on_time: str, off_time: str):
+    with Session(engine) as session:
+        settings = session.query(CabinetLightsSettings).filter(CabinetLightsSettings.id == 1).first()
+        if not settings:
+            settings = CabinetLightsSettings(
+                id=1,
+                current_r=r,
+                current_g=g,
+                current_b=b,
+                saved_r=r,
+                saved_g=g,
+                saved_b=b,
+                current_on_time=on_time,
+                current_off_time=off_time,
+                saved_on_time=on_time,
+                saved_off_time=off_time,
+            )
+            session.add(settings)
+            session.commit()
+
+def get_cabinet_lights_settings():
+    with Session(engine) as session:
+        settings = session.query(CabinetLightsSettings).filter(CabinetLightsSettings.id == 1).first()
+        if not settings:
+            logging.error("Cabinet light settings unset")
+            return None
+        return {
+            "r": settings.current_r,
+            "g": settings.current_g,
+            "b": settings.current_b,
+            "on_time": settings.current_on_time,
+            "off_time": settings.current_off_time,
+        }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,20 @@ services:
       io.balena.features.kernel-modules: '1'
     volumes:
       - database:/var/lib/dimepi
+  dimepi-api:
+    build: ./api
+    ports:
+      - "8000:8000"
+    environment:
+      - DIMEPI_DATABASE_PATH=/var/lib/dimepi/database.db
+    volumes:
+      - database:/var/lib/dimepi
+  dimepi-frontend:
+    build: ./frontend
+    ports:
+      - "8080:80"
+    depends_on:
+      - dimepi-api
   sonos-api:
     image: chrisns/docker-node-sonos-http-api
     ports:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.DS_Store
+npm-debug.log

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS build
+FROM node:22-slim AS build
 
 WORKDIR /app
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY index.html .
+COPY vite.config.js .
+COPY src ./src
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DimePi Tracks</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/App.jsx"></script>
+  </body>
+</html>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://dimepi-api:8000/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,885 @@
+{
+  "name": "frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@vitejs/plugin-react": "6.0.1",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "vite": "8.0.11"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "dev": "vite --host 0.0.0.0",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "6.0.1",
+    "vite": "8.0.11",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
+  },
+  "devDependencies": {}
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,338 @@
+:root {
+  color: #1d2528;
+  background: #f4f1ea;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.app-shell {
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
+  gap: 24px;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.track-list,
+.editor {
+  background: #ffffff;
+  border: 1px solid #ded8cc;
+  border-radius: 8px;
+  box-shadow: 0 16px 40px rgba(37, 31, 22, 0.08);
+}
+
+.track-list {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 48px);
+  overflow: hidden;
+}
+
+.list-header,
+.editor-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px;
+  border-bottom: 1px solid #ebe6dc;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 26px;
+  line-height: 1.1;
+}
+
+h2 {
+  margin-top: 4px;
+  font-size: 30px;
+  line-height: 1.1;
+}
+
+h3 {
+  margin-top: 4px;
+  font-size: 22px;
+  line-height: 1.15;
+}
+
+.list-header p,
+.track-meta small,
+.eyebrow {
+  color: #687173;
+}
+
+.eyebrow {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.search {
+  display: grid;
+  gap: 8px;
+  padding: 18px 24px;
+  border-bottom: 1px solid #ebe6dc;
+}
+
+label span {
+  color: #465053;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+input {
+  width: 100%;
+  min-height: 44px;
+  border: 1px solid #cfc7ba;
+  border-radius: 6px;
+  padding: 10px 12px;
+  color: #1d2528;
+  background: #fffdf9;
+}
+
+input[type="color"] {
+  min-height: 54px;
+  padding: 4px;
+}
+
+input:focus {
+  border-color: #2f7d72;
+  box-shadow: 0 0 0 3px rgba(47, 125, 114, 0.16);
+  outline: none;
+}
+
+.rows {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  overflow: auto;
+}
+
+.track-row {
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 68px;
+  padding: 10px;
+  text-align: left;
+  color: #1d2528;
+  background: transparent;
+}
+
+.track-row:hover,
+.track-row.selected {
+  background: #e9f2ef;
+}
+
+.key-badge {
+  display: inline-grid;
+  place-items: center;
+  min-width: 44px;
+  height: 44px;
+  border-radius: 6px;
+  color: #ffffff;
+  background: #26383a;
+  font-weight: 800;
+}
+
+.track-meta {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.track-meta strong,
+.track-meta small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.editor {
+  min-height: calc(100vh - 48px);
+}
+
+.track-form {
+  display: grid;
+  gap: 18px;
+  max-width: 680px;
+  padding: 24px;
+}
+
+.track-form label {
+  display: grid;
+  gap: 8px;
+}
+
+.lights-panel {
+  display: grid;
+  gap: 18px;
+  max-width: 680px;
+  padding: 24px;
+  border-top: 1px solid #ebe6dc;
+}
+
+.section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.status {
+  min-width: 72px;
+  border-radius: 999px;
+  padding: 6px 10px;
+  color: #2f675e;
+  background: #e5f2ee;
+  font-size: 13px;
+  font-weight: 800;
+  text-align: center;
+}
+
+.status.unsaved {
+  color: #8b4a12;
+  background: #faecd6;
+}
+
+.lights-grid {
+  display: grid;
+  grid-template-columns: 160px minmax(180px, 1fr) 1fr 1fr;
+  gap: 16px;
+  align-items: end;
+}
+
+.lights-grid label,
+.colour-picker {
+  display: grid;
+  gap: 8px;
+}
+
+.colour-readout {
+  display: flex;
+  align-items: flex-end;
+  min-height: 54px;
+  border: 1px solid #cfc7ba;
+  border-radius: 6px;
+  padding: 10px;
+}
+
+.colour-readout span {
+  border-radius: 4px;
+  padding: 5px 8px;
+  color: #ffffff;
+  background: rgba(0, 0, 0, 0.55);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding-top: 8px;
+}
+
+.actions button,
+.secondary {
+  min-height: 42px;
+  padding: 10px 16px;
+}
+
+.actions button[type="submit"] {
+  color: #ffffff;
+  background: #2f7d72;
+}
+
+.secondary {
+  color: #26383a;
+  background: #edf1ef;
+}
+
+.compact {
+  min-height: 36px;
+  padding: 8px 12px;
+}
+
+.danger {
+  color: #ffffff;
+  background: #a74335;
+}
+
+.error,
+.empty-state {
+  margin: 14px;
+  padding: 14px;
+  border-radius: 6px;
+}
+
+.error {
+  color: #7f2118;
+  background: #f8e4df;
+}
+
+.inline-error {
+  margin: 0;
+}
+
+.empty-state {
+  color: #687173;
+  background: #f8f6f0;
+}
+
+@media (max-width: 820px) {
+  .app-shell {
+    padding: 12px;
+  }
+
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .lights-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .track-list,
+  .editor {
+    min-height: auto;
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,6 +36,10 @@ function hexToRgb(hex) {
   };
 }
 
+function sortTracks(tracks) {
+  return [...tracks].sort((a, b) => a.key.localeCompare(b.key, undefined, { numeric: true, sensitivity: "base" }));
+}
+
 function App() {
   const [tracks, setTracks] = useState([]);
   const [selectedKey, setSelectedKey] = useState(null);
@@ -72,7 +76,7 @@ function App() {
       const response = await fetch(`${API_BASE}/tracks`);
       if (!response.ok) throw new Error("Could not load tracks");
       const data = await response.json();
-      setTracks(data);
+      setTracks(sortTracks(data));
       if (selectedKey && !data.some((track) => track.key === selectedKey)) {
         resetForm();
       }
@@ -181,9 +185,9 @@ function App() {
       setTracks((current) => {
         const exists = current.some((track) => track.key === saved.key);
         if (exists) {
-          return current.map((track) => (track.key === saved.key ? saved : track));
+          return sortTracks(current.map((track) => (track.key === saved.key ? saved : track)));
         }
-        return [...current, saved].sort((a, b) => a.key.localeCompare(b.key, undefined, { numeric: true }));
+        return sortTracks([...current, saved]);
       });
       setSelectedKey(saved.key);
       setForm(saved);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,408 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import "./App.css";
+
+const API_BASE = "/api";
+const emptyForm = {
+  key: "",
+  track_name: "",
+  artist_name: "",
+  spotify_id: "",
+};
+const defaultLightSettings = {
+  r: 255,
+  g: 90,
+  b: 0,
+  on_time: "07:00",
+  off_time: "22:00",
+  saved_r: 255,
+  saved_g: 90,
+  saved_b: 0,
+  saved_on_time: "07:00",
+  saved_off_time: "22:00",
+  has_unsaved_changes: false,
+};
+
+function rgbToHex({ r, g, b }) {
+  return `#${[r, g, b].map((value) => value.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function hexToRgb(hex) {
+  const value = hex.replace("#", "");
+  return {
+    r: parseInt(value.slice(0, 2), 16),
+    g: parseInt(value.slice(2, 4), 16),
+    b: parseInt(value.slice(4, 6), 16),
+  };
+}
+
+function App() {
+  const [tracks, setTracks] = useState([]);
+  const [selectedKey, setSelectedKey] = useState(null);
+  const [form, setForm] = useState(emptyForm);
+  const [filter, setFilter] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [lights, setLights] = useState(defaultLightSettings);
+  const [lightsBusy, setLightsBusy] = useState(false);
+  const [lightsError, setLightsError] = useState("");
+  const lightsPreviewRequest = useRef(0);
+
+  const selectedTrack = useMemo(
+    () => tracks.find((track) => track.key === selectedKey),
+    [tracks, selectedKey],
+  );
+
+  const filteredTracks = useMemo(() => {
+    const query = filter.trim().toLowerCase();
+    if (!query) return tracks;
+    return tracks.filter((track) =>
+      [track.key, track.track_name, track.artist_name, track.spotify_id]
+        .join(" ")
+        .toLowerCase()
+        .includes(query),
+    );
+  }, [tracks, filter]);
+
+  async function loadTracks() {
+    setLoading(true);
+    setError("");
+    try {
+      const response = await fetch(`${API_BASE}/tracks`);
+      if (!response.ok) throw new Error("Could not load tracks");
+      const data = await response.json();
+      setTracks(data);
+      if (selectedKey && !data.some((track) => track.key === selectedKey)) {
+        resetForm();
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function loadCabinetLights() {
+    setLightsError("");
+    try {
+      const response = await fetch(`${API_BASE}/cabinet-lights`);
+      if (!response.ok) throw new Error("Could not load cabinet light settings");
+      setLights(await response.json());
+    } catch (err) {
+      setLightsError(err.message);
+    }
+  }
+
+  useEffect(() => {
+    loadTracks();
+    loadCabinetLights();
+  }, []);
+
+  useEffect(() => {
+    function revertUnsavedLights() {
+      if (!lights.has_unsaved_changes) return;
+      if (navigator.sendBeacon) {
+        navigator.sendBeacon(`${API_BASE}/cabinet-lights/revert`, new Blob([], { type: "application/json" }));
+        return;
+      }
+      fetch(`${API_BASE}/cabinet-lights/revert`, { method: "POST", keepalive: true });
+    }
+
+    window.addEventListener("pagehide", revertUnsavedLights);
+    return () => window.removeEventListener("pagehide", revertUnsavedLights);
+  }, [lights.has_unsaved_changes]);
+
+  function resetForm() {
+    setSelectedKey(null);
+    setForm(emptyForm);
+    setError("");
+  }
+
+  function selectTrack(track) {
+    setSelectedKey(track.key);
+    setForm({
+      key: track.key,
+      track_name: track.track_name || "",
+      artist_name: track.artist_name || "",
+      spotify_id: track.spotify_id || "",
+    });
+    setError("");
+  }
+
+  function updateField(event) {
+    const { name, value } = event.target;
+    setForm((current) => ({ ...current, [name]: value }));
+  }
+
+  async function saveTrack(event) {
+    event.preventDefault();
+    setSaving(true);
+    setError("");
+
+    const trimmed = {
+      key: form.key.trim(),
+      track_name: form.track_name.trim(),
+      artist_name: form.artist_name.trim(),
+      spotify_id: form.spotify_id.trim(),
+    };
+
+    if (!trimmed.key || !trimmed.spotify_id) {
+      setSaving(false);
+      setError("Key and Spotify ID are required.");
+      return;
+    }
+
+    try {
+      const isEditing = Boolean(selectedTrack);
+      const response = await fetch(
+        isEditing ? `${API_BASE}/tracks/${encodeURIComponent(selectedKey)}` : `${API_BASE}/tracks`,
+        {
+          method: isEditing ? "PUT" : "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            isEditing
+              ? {
+                  track_name: trimmed.track_name,
+                  artist_name: trimmed.artist_name,
+                  spotify_id: trimmed.spotify_id,
+                }
+              : trimmed,
+          ),
+        },
+      );
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.detail || "Could not save track");
+      }
+
+      const saved = await response.json();
+      setTracks((current) => {
+        const exists = current.some((track) => track.key === saved.key);
+        if (exists) {
+          return current.map((track) => (track.key === saved.key ? saved : track));
+        }
+        return [...current, saved].sort((a, b) => a.key.localeCompare(b.key, undefined, { numeric: true }));
+      });
+      setSelectedKey(saved.key);
+      setForm(saved);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function deleteTrack() {
+    if (!selectedKey) return;
+    setSaving(true);
+    setError("");
+    try {
+      const response = await fetch(`${API_BASE}/tracks/${encodeURIComponent(selectedKey)}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) throw new Error("Could not delete track");
+      setTracks((current) => current.filter((track) => track.key !== selectedKey));
+      resetForm();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function previewCabinetLights(nextSettings) {
+    const requestId = ++lightsPreviewRequest.current;
+    setLightsError("");
+    try {
+      const response = await fetch(`${API_BASE}/cabinet-lights/preview`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(nextSettings),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.detail || "Could not preview cabinet light settings");
+      }
+      const nextLights = await response.json();
+      if (requestId === lightsPreviewRequest.current) {
+        setLights(nextLights);
+      }
+    } catch (err) {
+      setLightsError(err.message);
+    }
+  }
+
+  function updateCabinetColor(event) {
+    const rgb = hexToRgb(event.target.value);
+    setLights((current) => ({ ...current, ...rgb, has_unsaved_changes: true }));
+    previewCabinetLights(rgb);
+  }
+
+  function updateCabinetTime(event) {
+    const { name, value } = event.target;
+    setLights((current) => ({ ...current, [name]: value, has_unsaved_changes: true }));
+    previewCabinetLights({ [name]: value });
+  }
+
+  async function saveCabinetLights() {
+    lightsPreviewRequest.current += 1;
+    setLightsBusy(true);
+    setLightsError("");
+    try {
+      const response = await fetch(`${API_BASE}/cabinet-lights/save`, { method: "POST" });
+      if (!response.ok) throw new Error("Could not save cabinet light settings");
+      setLights(await response.json());
+    } catch (err) {
+      setLightsError(err.message);
+    } finally {
+      setLightsBusy(false);
+    }
+  }
+
+  async function revertCabinetLights() {
+    lightsPreviewRequest.current += 1;
+    setLightsBusy(true);
+    setLightsError("");
+    try {
+      const response = await fetch(`${API_BASE}/cabinet-lights/revert`, { method: "POST" });
+      if (!response.ok) throw new Error("Could not revert cabinet light settings");
+      setLights(await response.json());
+    } catch (err) {
+      setLightsError(err.message);
+    } finally {
+      setLightsBusy(false);
+    }
+  }
+
+  return (
+    <main className="app-shell">
+      <section className="workspace">
+        <aside className="track-list" aria-label="Tracks">
+          <div className="list-header">
+            <div>
+              <h1>DimePi Tracks</h1>
+              <p>{tracks.length} saved selections</p>
+            </div>
+            <button type="button" className="secondary compact" onClick={loadTracks} disabled={loading}>
+              Refresh
+            </button>
+          </div>
+
+          <label className="search">
+            <span>Search</span>
+            <input value={filter} onChange={(event) => setFilter(event.target.value)} placeholder="Key, title, artist, Spotify ID" />
+          </label>
+
+          <div className="rows">
+            {loading ? <div className="empty-state">Loading tracks...</div> : null}
+            {!loading && filteredTracks.length === 0 ? <div className="empty-state">No tracks found.</div> : null}
+            {filteredTracks.map((track) => (
+              <button
+                type="button"
+                className={track.key === selectedKey ? "track-row selected" : "track-row"}
+                key={track.key}
+                onClick={() => selectTrack(track)}
+              >
+                <span className="key-badge">{track.key}</span>
+                <span className="track-meta">
+                  <strong>{track.track_name || "Untitled track"}</strong>
+                  <small>{track.artist_name || "Unknown artist"}</small>
+                </span>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <section className="editor" aria-label="Track editor">
+          <div className="editor-header">
+            <div>
+              <p className="eyebrow">{selectedTrack ? "Editing selection" : "New selection"}</p>
+              <h2>{selectedTrack ? selectedTrack.key : "Add a track"}</h2>
+            </div>
+            <button type="button" className="secondary" onClick={resetForm}>
+              New
+            </button>
+          </div>
+
+          {error ? <div className="error">{error}</div> : null}
+
+          <form className="track-form" onSubmit={saveTrack}>
+            <label>
+              <span>Keypad code</span>
+              <input name="key" value={form.key} onChange={updateField} disabled={Boolean(selectedTrack)} required />
+            </label>
+
+            <label>
+              <span>Track name</span>
+              <input name="track_name" value={form.track_name} onChange={updateField} />
+            </label>
+
+            <label>
+              <span>Artist</span>
+              <input name="artist_name" value={form.artist_name} onChange={updateField} />
+            </label>
+
+            <label>
+              <span>Spotify ID or URI</span>
+              <input name="spotify_id" value={form.spotify_id} onChange={updateField} required />
+            </label>
+
+            <div className="actions">
+              <button type="submit" disabled={saving}>
+                {saving ? "Saving..." : "Save track"}
+              </button>
+              <button type="button" className="danger" onClick={deleteTrack} disabled={!selectedTrack || saving}>
+                Delete
+              </button>
+            </div>
+          </form>
+
+          <section className="lights-panel" aria-label="Cabinet light settings">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Cabinet lights</p>
+                <h3>Colour and schedule</h3>
+              </div>
+              <span className={lights.has_unsaved_changes ? "status unsaved" : "status"}>{lights.has_unsaved_changes ? "Unsaved" : "Saved"}</span>
+            </div>
+
+            {lightsError ? <div className="error inline-error">{lightsError}</div> : null}
+
+            <div className="lights-grid">
+              <label className="colour-picker">
+                <span>Colour</span>
+                <input type="color" value={rgbToHex(lights)} onChange={updateCabinetColor} />
+              </label>
+              <div className="colour-readout" style={{ background: rgbToHex(lights) }}>
+                <span>
+                  RGB {lights.r}, {lights.g}, {lights.b}
+                </span>
+              </div>
+              <label>
+                <span>On time</span>
+                <input type="time" name="on_time" value={lights.on_time} onChange={updateCabinetTime} />
+              </label>
+              <label>
+                <span>Off time</span>
+                <input type="time" name="off_time" value={lights.off_time} onChange={updateCabinetTime} />
+              </label>
+            </div>
+
+            <div className="actions">
+              <button type="button" onClick={saveCabinetLights} disabled={lightsBusy || !lights.has_unsaved_changes}>
+                {lightsBusy ? "Saving..." : "Save lights"}
+              </button>
+              <button type="button" className="secondary" onClick={revertCabinetLights} disabled={lightsBusy || !lights.has_unsaved_changes}>
+                Revert
+              </button>
+            </div>
+          </section>
+        </section>
+      </section>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")).render(<App />);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
+  },
+});

--- a/main.py
+++ b/main.py
@@ -15,7 +15,6 @@ from functools import partial
 import asyncio
 import logging
 import configparser
-from datetime import datetime
 import cabinet_lights
 
 logger = logging.getLogger()
@@ -40,17 +39,17 @@ queuemode = config['sonos']['queuemode']
 queueclear = config['sonos'].getboolean('queueclear')
 coinslot_gpio_pin = config['general'].getint('coinslot_gpio_pin')
 cabinet_lights_colour = config['general']['cabinet_lights_colour'].split(",")
-lights_on_time = datetime.strptime(config['general']['cabinet_lights_on_time'], '%H:%M').time()
-lights_off_time = datetime.strptime(config['general']['cabinet_lights_off_time'], '%H:%M').time()
 
 last_coin_time = 0
 DEBOUNCE_TIME = config['general'].getfloat('coin_debounce_time')
 _gpio_initialized = False
+IDLE_POLL_INTERVAL = 0.1
 
 async def jukebox_handler(queue,keypad,sonos):
     while True:
         if database.get_credits() >= 1:
-            keypad.set_credit_light_on()
+            if keypad.get_credit_light() is not False:
+                keypad.set_credit_light_on()
             # Get a "work item" out of the queue.
             output = await queue.get()
 
@@ -59,14 +58,16 @@ async def jukebox_handler(queue,keypad,sonos):
 
             logging.debug(f'Track selection detected on queue: {output}')
             logging.info(f"Matched to song in database. Playing song {database.get_track_name(output)} by {database.get_artist_name(output)}")
-            result = sonos.set_track(database.get_track_id(output))
+            result = await sonos.set_track(database.get_track_id(output))
             if result:
                 logging.debug(f"Track successfully queued.")
                 database.decrement_credits()
             else:
                 logging.error("Track does not exist. No credits decremented")
         else:
-            keypad.set_credit_light_off()
+            if keypad.get_credit_light() is not True:
+                keypad.set_credit_light_off()
+            await asyncio.sleep(IDLE_POLL_INTERVAL)
 
 def coinslot_handler():
     global _gpio_initialized
@@ -91,9 +92,18 @@ def coinslot_callback(channel):
 
 def main():
     loop = None
+    sonos = None
+    tasks = []
     loop = asyncio.get_event_loop()
     try:
         r, g, b = int(cabinet_lights_colour[0]), int(cabinet_lights_colour[1]), int(cabinet_lights_colour[2])
+        database.ensure_cabinet_lights_settings(
+            r,
+            g,
+            b,
+            config['general']['cabinet_lights_on_time'],
+            config['general']['cabinet_lights_off_time'],
+        )
         cabinet_lights_pixels = cabinet_lights.initialize(r, g, b)
         keypad_queue = asyncio.Queue()
         keypad = Keypad(keypad_queue)
@@ -104,7 +114,7 @@ def main():
         tasks = [
             loop.create_task(keypad.get_key_combination()),
             loop.create_task(jukebox_handler(keypad_queue, keypad, sonos)),
-            loop.create_task(cabinet_lights.scheduler(cabinet_lights_pixels, r, g, b, lights_on_time, lights_off_time))
+            loop.create_task(cabinet_lights.scheduler(cabinet_lights_pixels, database.get_cabinet_lights_settings))
         ]
 
         loop.run_forever()
@@ -113,6 +123,8 @@ def main():
         for task in tasks:
             task.cancel()
         loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
+        if sonos:
+            loop.run_until_complete(sonos.close())
         GPIO.cleanup()
         if loop:
             loop.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Adafruit_Blinka==7.4.0
 adafruit_circuitpython_mcp230xx==2.4.6
 board==1.0
-requests==2.21.0
+httpx==0.27.0
 rpi-lgpio==0.6
 sqlmodel==0.0.6
 rpi_ws281x==4.3.4

--- a/sonos_interface.py
+++ b/sonos_interface.py
@@ -1,25 +1,43 @@
-import requests
 import logging
+from urllib.parse import quote
+
+import httpx
 
 
 class SonosInterface:
     def __init__(self, url, zone, queuemode, queueclear):
-        self.url = url
+        self.url = url.rstrip("/")
         self.zone = zone
         self.queuemode = queuemode
         self.queueclear = queueclear
+        self.client = httpx.AsyncClient(timeout=10.0)
 
-    def set_track(self,track_id):
+    def _url(self, *parts):
+        path = "/".join(quote(str(part), safe=":") for part in parts)
+        return f"{self.url}/{path}"
+
+    async def _get(self, *parts):
+        try:
+            response = await self.client.get(self._url(self.zone, *parts))
+            logging.debug("Request: " + response.text)
+            return response
+        except httpx.HTTPError as e:
+            logging.error(f"Sonos API request failed: {e}")
+            return None
+
+    async def close(self):
+        await self.client.aclose()
+
+    async def set_track(self,track_id):
         if isinstance(track_id,str):
-            if not self.is_playing():
+            if not await self.is_playing():
                 if self.queueclear:
-                    self.clearQueue()
-            r = requests.get(self.url + '/' + self.zone + '/spotify/' + self.queuemode + '/spotify:track:' + track_id)
-            logging.debug('Request: ' + r.text)
-            if not self.is_playing():
-                self.play()
+                    await self.clearQueue()
+            r = await self._get("spotify", self.queuemode, "spotify:track:" + track_id)
+            if not await self.is_playing():
+                await self.play()
 
-            if r.status_code == 200:
+            if r and r.status_code == 200:
                 return True
             else:
                 return False
@@ -27,29 +45,22 @@ class SonosInterface:
             logging.error('Invalid track')
             return False
 
-    def is_playing(self):
-        r = requests.get(self.url + '/' + self.zone + '/state')
-        logging.debug('Request: ' + r.text)
-        if r.status_code == 200:
-            if r.json()['playbackState'] == 'PLAYING':
-                return True
-            else:
-                return False
-        else:
-            return False
+    async def is_playing(self):
+        r = await self._get("state")
+        if r and r.status_code == 200:
+            return r.json().get('playbackState') == 'PLAYING'
+        return False
 
-    def play(self):
-        r = requests.get(self.url + '/' + self.zone + '/play')
-        logging.debug('Request: ' + r.text)
-        if r.status_code == 200:
+    async def play(self):
+        r = await self._get("play")
+        if r and r.status_code == 200:
             return True
         else:
             return False
 
-    def clearQueue(self):
-        r = requests.get(self.url + '/' + self.zone + '/clearqueue')
-        logging.debug('Request: ' + r.text)
-        if r.status_code == 200:
+    async def clearQueue(self):
+        r = await self._get("clearqueue")
+        if r and r.status_code == 200:
             return True
         else:
             return False


### PR DESCRIPTION
## Summary

Adds a containerized admin surface for DimePi and moves cabinet light settings into the shared SQLite database so they can be edited from the UI.

## What changed

- Added a lightweight FastAPI admin API container for track CRUD and cabinet-light settings.
- Added a React/Vite frontend served by nginx, with track add/edit/delete controls and cabinet-light colour/schedule controls.
- Wired the API and frontend into Docker Compose as separate services sharing the existing database volume.
- Updated the main app to poll DB-backed cabinet-light settings, allowing live colour preview and saved on/off schedules without giving the web container GPIO access.
- Replaced blocking Sonos requests calls with httpx.AsyncClient and fixed the idle jukebox loop so it yields instead of spinning.
- Slimmed the main image build context and Dockerfile install path.

## Impact

Admins can now manage track selections through http://localhost:8080, preview cabinet-light colour changes live, save or revert those changes, and adjust the cabinet-light on/off schedule. The main GPIO process remains separate from the admin web services.

## Validation

- python3 -m py_compile main.py cabinet_lights.py database.py api/main.py
- npm run build
- docker compose build dimepi-api dimepi-frontend dimepi
- Smoke-tested GET /cabinet-lights, PATCH /cabinet-lights/preview, and POST /cabinet-lights/revert inside the API container.

## Notes

The physical live cabinet-light update requires the rebuilt dimepi container to be running, because that is the container with GPIO access.